### PR TITLE
Fix missing FC import causing ce errors

### DIFF
--- a/src/components/shared/AIToolContent.tsx
+++ b/src/components/shared/AIToolContent.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { useState } from 'react';
+import React, { FC, useState } from 'react';
 import { Copy, Download, RefreshCw } from 'lucide-react';
 
 const AIToolContent: FC<AIToolContentProps> = ({


### PR DESCRIPTION
### **User description**
## Summary
- import `FC` in `AIToolContent` so the component type is properly defined

## Testing
- `npm run build` *(fails: Transform failed with 10 errors in `App.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68878f956764832b9aba249494d29bd8


___

### **PR Type**
Bug fix


___

### **Description**
- Import `FC` type from React to fix TypeScript compilation errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Missing FC import"] --> B["TypeScript compilation error"] 
  C["Add FC to React imports"] --> D["Fixed component typing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AIToolContent.tsx</strong><dd><code>Add missing FC import for component typing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/shared/AIToolContent.tsx

<ul><li>Consolidated React imports to include <code>FC</code> type<br> <li> Fixed missing TypeScript type definition for component</ul>


</details>


  </td>
  <td><a href="https://github.com/deangilmoreremix/update3.0-new/pull/13/files#diff-181eb780c202be43d77f6435b41cc64b83b3e1a28f864fd4f68377a1e7b7f03f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified and consolidated import statements for improved code readability. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->