### PR TITLE
fix: correct TaskCalendar imports

### DIFF
--- a/TaskCalendar.tsx
+++ b/TaskCalendar.tsx
@@ -1,11 +1,9 @@
 import React, { useState, useMemo } from 'react';
 import { Calendar, momentLocalizer } from 'react-big-calendar';
 import moment from 'moment';
-import { Task } from '../types';
-import { useTaskStore } from '../store/taskStore';
+import { Task } from './types';
+import { useTaskStore } from '@/store/taskStore';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
-import { Calendar } from 'lucide-react';
-import { Navigate } from 'react-router-dom';
 
 // Setup localizer for react-big-calendar
 const localizer = momentLocalizer(moment);


### PR DESCRIPTION
### **User description**
## Summary
- fix Task and store imports in TaskCalendar
- drop unused lucide Calendar and Navigate imports

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_6892261f479c832ba304f97b290d8903


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect import paths for Task type and useTaskStore

- Remove unused lucide-react Calendar and react-router-dom Navigate imports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TaskCalendar.tsx"] --> B["Fix Task import path"]
  A --> C["Fix useTaskStore import path"]
  A --> D["Remove unused imports"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TaskCalendar.tsx</strong><dd><code>Fix import paths and remove unused imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

TaskCalendar.tsx

<ul><li>Updated Task import from '../types' to './types'<br> <li> Updated useTaskStore import to use '@/' alias<br> <li> Removed unused Calendar import from lucide-react<br> <li> Removed unused Navigate import from react-router-dom</ul>


</details>


  </td>
  <td><a href="https://github.com/deangilmoreremix/update3.0-new/pull/15/files#diff-7262b4b4a05556e6ce217128741412c6b525d4aeba91a366a26762f79217c757">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code organization by updating import paths and removing unused imports. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->